### PR TITLE
ci: support the latest version of the tagging github action (PD-16)

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -157,10 +157,10 @@ jobs:
     with:
       target-branch: ${{ needs.initialize.outputs.latest-release }}
       jira-domain: ${{ vars.JIRA_DOMAIN }}
-      jira-username: ${{ vars.JIRA_USERNAME }}
       is-release: true
     secrets:
       jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
+      jira-username: ${{ vars.JIRA_USERNAME }}
       llm-api-token: ${{ secrets.LLM_TOKEN }}
   deploy-to-production:
     name: Ready for production

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -153,7 +153,7 @@ jobs:
           fi
   tag-predicted-release:
     needs: [deploy-to-testing,initialize]
-    uses: VirdocsSoftware/github-actions/.github/workflows/tag-tickets-with-release.yml@hotfix/v2.4.4
+    uses: VirdocsSoftware/github-actions/.github/workflows/tag-tickets-with-release.yml@main
     with:
       target-branch: ${{ needs.initialize.outputs.latest-release }}
       jira-domain: ${{ vars.JIRA_DOMAIN }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
   release:
-    types: [ published ]
+    types: [published]
 
 jobs:
   initialize:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
   initialize:

--- a/project1/README.md
+++ b/project1/README.md
@@ -1,3 +1,3 @@
 # Test project
 
-Date: 2024-11-27 8:39 am
+Date: 2024-11-27 4:56pm am


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the date in the README.md file for accuracy.
- **Chores**
	- Adjusted formatting in the GitHub Actions workflow configuration for the release event trigger.
	- Changed the reference for the `tag-predicted-release` job to use the main branch for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->